### PR TITLE
Move from patching to overwriting kops resources. Maintain more state…

### DIFF
--- a/cmd/wk/main.go
+++ b/cmd/wk/main.go
@@ -77,7 +77,7 @@ var clusterEditCmd = &cobra.Command{
 var clusterEditIGCmd = &cobra.Command{
 	Use:    "cluster-edit-ig",
 	Hidden: true,
-	Args:   cobra.ExactArgs(5),
+	Args:   cobra.ExactArgs(6),
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := kops.ClusterEditIG(context.Background(), args); err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/pkg/sftp v1.10.0 // indirect
 	github.com/sirupsen/logrus v1.4.1
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
@@ -25,13 +24,13 @@ require (
 	golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd // indirect
 	golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6 // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
-	golang.org/x/sys v0.0.0-20190424175732-18eb32c0e2f0 // indirect
 	golang.org/x/text v0.3.1 // indirect
 	google.golang.org/api v0.3.2 // indirect
 	google.golang.org/appengine v1.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7 // indirect
 	google.golang.org/grpc v1.20.1 // indirect
 	gopkg.in/ini.v1 v1.46.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/apimachinery v0.0.0-20190424132444-f1e86e15343c // indirect
 	k8s.io/client-go v11.0.0+incompatible // indirect
 	k8s.io/kops v1.11.1-0.20190301151100-0f2aa8d30d89

--- a/go.sum
+++ b/go.sum
@@ -117,9 +117,11 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2 h1:NAfh7zF0/3/HqtMvJNZ/RFrSlCE6ZTlHmKfhL/Dm1Jk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
@@ -164,6 +166,8 @@ golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190424175732-18eb32c0e2f0 h1:V+O002es++Mnym06Rj/S6Fl7VCsgRBgVDGb/NoZVHUg=
 golang.org/x/sys v0.0.0-20190424175732-18eb32c0e2f0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190507053917-2953c62de483 h1:0pONs62zZ8ED8kUnSCsv4RWjmwM6ideAalXGTybpo2s=
+golang.org/x/sys v0.0.0-20190507053917-2953c62de483/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/pkg/kops/state.go
+++ b/pkg/kops/state.go
@@ -2,12 +2,72 @@ package kops
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
+	// "bitbucket.org/avd/go-ipc/sync"
 )
 
+// State represents the results of running `kops edit cluster` and `kops edit ig`
+// across multiple resources
 type State struct {
+	Cluster        ObjectState
+	InstanceGroups map[string]ObjectState
+}
+
+// ObjectState represents the results of running `kops edit cluster` or `kops edit ig`
+type ObjectState struct {
 	UpdateRequired bool
+	DiffText       string
+}
+
+func (s *State) requiresUpdate() bool {
+	if s.Cluster.UpdateRequired {
+		return true
+	}
+	for _, ig := range s.InstanceGroups {
+		if ig.UpdateRequired {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *State) renderDiffs() string {
+	r := ""
+	if s.Cluster.DiffText != "" {
+		r += fmt.Sprintf("Cluster changed:\n%v\n\n", s.Cluster.DiffText)
+	}
+	for name, ig := range s.InstanceGroups {
+		if ig.DiffText != "" {
+			r += fmt.Sprintf("Instance Group %v changed:\n%v\n\n", name, ig.DiffText)
+		}
+	}
+	if r == "" {
+		r = "No changes."
+	}
+	return r
+}
+
+func newState() *State {
+	return &State{
+		InstanceGroups: make(map[string]ObjectState),
+	}
+}
+
+func updateState(path string, upFunc func(s *State)) {
+	stateb, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	s := &State{}
+	if err := json.Unmarshal(stateb, s); err != nil {
+		panic(err)
+	}
+
+	upFunc(s)
+	sb, _ := json.Marshal(s)
+	ioutil.WriteFile(path, sb, os.ModePerm)
 }
 
 func getState(path string) *State {
@@ -20,9 +80,4 @@ func getState(path string) *State {
 		panic(err)
 	}
 	return s
-}
-
-func saveState(s *State, path string) {
-	sb, _ := json.Marshal(s)
-	ioutil.WriteFile(path, sb, os.ModePerm)
 }

--- a/pkg/kops/util.go
+++ b/pkg/kops/util.go
@@ -1,16 +1,13 @@
 package kops
 
 import (
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"reflect"
 	"strings"
 
-	"github.com/imdario/mergo"
-	"github.com/kylelemons/godebug/diff"
+	godebug_diff "github.com/kylelemons/godebug/diff"
 	"github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
 
 	"github.com/wish/wk/pkg/types"
 	"github.com/wish/wk/pkg/util"
@@ -28,48 +25,24 @@ func ReadClusterFile(path string) (*types.Cluster, error) {
 	return cluster, nil
 }
 
-func patch(data []byte, patch map[string]interface{}) (bool, []byte, error) {
-	if bytes.HasPrefix(data, []byte{'#'}) && bytes.Contains(data, []byte("# ...")) {
-		for _, line := range bytes.Split(data, []byte{'\n'}) {
-			if !bytes.HasPrefix(line, []byte{'#'}) {
-				break
-			}
-			logrus.Infoln(line)
-		}
-	}
-	src := &map[string]interface{}{}
-	dst := &map[string]interface{}{}
-	var err error
-
-	if err = yaml.Unmarshal(data, src); err != nil {
-		return false, nil, err
-	}
-	if err = yaml.Unmarshal(data, dst); err != nil {
-		return false, nil, err
-	}
-	if err = mergo.Merge(dst, patch, mergo.WithOverride); err != nil {
-		return false, nil, err
-	}
-
-	if !reflect.DeepEqual(*src, *dst) {
+// diff returns whether the structures are different, and a textual diff of the changes
+func diff(old, new map[string]interface{}) (bool, string) {
+	if !reflect.DeepEqual(old, new) {
 		var A, B []byte
-		if A, err = json.MarshalIndent(src, "", "  "); err != nil {
-			return false, nil, err
+		var err error
+		if A, err = json.MarshalIndent(&old, "", "  "); err != nil {
+			logrus.Fatalf("Error marshalling old to JSON: %v", err)
 		}
-		if B, err = json.MarshalIndent(dst, "", "  "); err != nil {
-			return false, nil, err
+		if B, err = json.MarshalIndent(&new, "", "  "); err != nil {
+			logrus.Fatalf("Error marshalling new to JSON: %v", err)
 		}
-		logrus.Infoln(util.Render(diff.DiffChunks(
+		textDiff := util.Render(godebug_diff.DiffChunks(
 			strings.Split(string(A), "\n"),
 			strings.Split(string(B), "\n"),
-		)))
+		))
 
-		y, err := yaml.Marshal(dst)
-		if err != nil {
-			return false, nil, err
-		}
-		return false, y, nil
+		return false, textDiff
 	}
 
-	return true, nil, nil
+	return true, ""
 }


### PR DESCRIPTION
… from subcommands

This PR does a few things:

- For clusters and igs, the incoming file should overwrite, not be merged into, the existing one.
- Add more state passing from the child processes to the parent. Not too useful now, more useful if can ever figure out concurrently updating igs.
- instancegroup updates respect `--preview`