### PR TITLE
Copy files instead of renaming them for docker compatibility

### DIFF
--- a/pkg/kops/channels.go
+++ b/pkg/kops/channels.go
@@ -88,7 +88,7 @@ func ChannelsApply(ctx context.Context, file, dryFile string) error {
 							if err2 := os.MkdirAll(filepath.Dir(tfile), os.ModePerm); err2 != nil {
 								err = err2
 							}
-							if err2 := os.Rename(outFile, tfile); err2 != nil {
+							if err2 := CopyFile(outFile, tfile); err2 != nil {
 								err = err2
 							}
 							chItems = append(chItems, channelItem{

--- a/pkg/kops/cluster.go
+++ b/pkg/kops/cluster.go
@@ -30,10 +30,8 @@ func ClusterApply(ctx context.Context, file, dryFile string, forceUpdate, previe
 		if err := os.MkdirAll(filepath.Dir(dryFile), os.ModePerm); err != nil {
 			return err
 		}
-		if err := os.Rename(tfile, dryFile); err != nil {
-			return err
-		}
-		return nil
+
+		return CopyFile(tfile, dryFile)
 	}
 
 	s := newState()

--- a/pkg/kops/util.go
+++ b/pkg/kops/util.go
@@ -2,7 +2,9 @@ package kops
 
 import (
 	"encoding/json"
+	"io"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 
@@ -12,6 +14,23 @@ import (
 	"github.com/wish/wk/pkg/types"
 	"github.com/wish/wk/pkg/util"
 )
+
+func CopyFile(src, dest string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, sourceFile)
+	return err
+}
 
 func ReadClusterFile(path string) (*types.Cluster, error) {
 	out, err := ioutil.ReadFile(path)


### PR DESCRIPTION
You can't rename a file that only exists inside the container fs to one that exists in a mounted dir.