### PR TITLE
Add no-update flag

### DIFF
--- a/cmd/wk/main.go
+++ b/cmd/wk/main.go
@@ -20,6 +20,7 @@ func init() {
 	clusterApplyCmd.Flags().StringP("dry", "", "", "Run dry run and save output file.")
 	clusterApplyCmd.Flags().BoolP("force-update", "f", false, "Force update")
 	clusterApplyCmd.Flags().BoolP("preview", "p", false, "Preview changes")
+	clusterApplyCmd.Flags().BoolP("no-update", "n", false, "Create resources but don't do kops update cluster")
 
 	opa.AddOPAOpts(clusterApplyCmd)
 
@@ -58,13 +59,14 @@ var clusterApplyCmd = &cobra.Command{
 		dry, _ := cmd.Flags().GetString("dry")
 		forceUpdate, _ := cmd.Flags().GetBool("force-update")
 		preview, _ := cmd.Flags().GetBool("preview")
+		noUpdate, _ := cmd.Flags().GetBool("no-update")
 		opaQuery, err := opa.FromFlags(cmd.Flags())
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
-		if err := kops.ClusterApply(context.Background(), args[0], dry, forceUpdate, preview, opaQuery); err != nil {
+		if err := kops.ClusterApply(context.Background(), args[0], dry, forceUpdate, noUpdate, preview, opaQuery); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/pkg/kops/cluster.go
+++ b/pkg/kops/cluster.go
@@ -19,7 +19,7 @@ import (
 	"github.com/wish/wk/pkg/util"
 )
 
-func ClusterApply(ctx context.Context, file, dryFile string, forceUpdate, preview bool, opaQuery *opa.OPA) error {
+func ClusterApply(ctx context.Context, file, dryFile string, forceUpdate, noUpdate, preview bool, opaQuery *opa.OPA) error {
 	cluster, tfile, err := jsonnet.ExpandCluster(ctx, file)
 	if err != nil {
 		return err
@@ -107,7 +107,7 @@ func ClusterApply(ctx context.Context, file, dryFile string, forceUpdate, previe
 	}
 
 	s = getState(statefile)
-	if !preview && (s.requiresUpdate() || forceUpdate) {
+	if !preview && !noUpdate && (s.requiresUpdate() || forceUpdate) {
 		logrus.Infoln("Update is required. Issuing update.")
 
 		uCmd := exec.CommandContext(ctx, "kops", "update", "cluster", "--name="+cluster.Name, "-v1", "--yes", "--create-kube-config=false")


### PR DESCRIPTION
Add a `--no-update` flag to `wk cluster` to force only updating the YAMLs, not running `kops update`.